### PR TITLE
reshetnyak.igor/T2

### DIFF
--- a/reshetnyak.igor/T0/main.cpp
+++ b/reshetnyak.igor/T0/main.cpp
@@ -1,0 +1,7 @@
+#include <iostream>
+
+int main()
+{
+  std::cout << "reshetnyak.igor\n";
+  return 0;
+}

--- a/reshetnyak.igor/T0/main.cpp
+++ b/reshetnyak.igor/T0/main.cpp
@@ -1,7 +1,0 @@
-#include <iostream>
-
-int main()
-{
-  std::cout << "reshetnyak.igor\n";
-  return 0;
-}

--- a/reshetnyak.igor/T2/DataStruct.cpp
+++ b/reshetnyak.igor/T2/DataStruct.cpp
@@ -1,19 +1,19 @@
 ﻿#include "DataStruct.h"
 
 StreamGuard::StreamGuard(std::basic_ios<char>& s) :
-	s_(s),
-	width_(s.width()),
-	fill_(s.fill()),
-	precision_(s.precision()),
-	fmt_(s.flags())
+    s_(s),
+    width_(s.width()),
+    fill_(s.fill()),
+    precision_(s.precision()),
+    fmt_(s.flags())
 {}
 
 StreamGuard::~StreamGuard()
 {
-	s_.width(width_);
-	s_.fill(fill_);
-	s_.precision(precision_);
-	s_.flags(fmt_);
+    s_.width(width_);
+    s_.fill(fill_);
+    s_.precision(precision_);
+    s_.flags(fmt_);
 }
 
 std::complex<double> parse_complex(const std::string& input)
@@ -29,14 +29,13 @@ std::complex<double> parse_complex(const std::string& input)
 std::istream& operator>>(std::istream& in, DelimiterIO&& data)
 {
     std::istream::sentry sentry(in);
-    if (!sentry)
-    {
+    if (!sentry) {
         return in;
     }
+
     char c = '0';
     in >> c;
-    if (in && c != data.exp)
-    {
+    if (in && c != data.exp) {
         in.setstate(std::ios::failbit);
     }
     return in;
@@ -45,22 +44,22 @@ std::istream& operator>>(std::istream& in, DelimiterIO&& data)
 std::istream& operator>>(std::istream& in, LabelIO& data)
 {
     std::istream::sentry sentry(in);
-    if (!sentry)
-    {
+    if (!sentry) {
         return in;
     }
+
     std::string s = "";
     in >> s;
     bool invalidInput = in.eof() || s.length() != 4;
-    if (!invalidInput)
-    {
-        invalidInput = s.substr(0, 3) != "key" || !(std::isdigit(s.c_str()[3]));
+    if (!invalidInput) {
+        invalidInput = s.substr(0, 3) != "key" || !std::isdigit(s[3]);
     }
-    if (invalidInput)
-    {
+
+    if (invalidInput) {
         in.setstate(std::ios::failbit);
         return in;
     }
+
     data.exp = s;
     return in;
 }
@@ -68,8 +67,7 @@ std::istream& operator>>(std::istream& in, LabelIO& data)
 std::istream& operator>>(std::istream& in, DataStruct& data)
 {
     std::istream::sentry sentry(in);
-    if (!sentry)
-    {
+    if (!sentry) {
         return in;
     }
 
@@ -77,95 +75,89 @@ std::istream& operator>>(std::istream& in, DataStruct& data)
     std::complex<double> key2;
     std::string key3;
     DataStruct temp;
-    {
-        char c;
-        using sep = DelimiterIO;
-        LabelIO label{ "" };
-        int itter = 0;
-        int option = 0;
-        bool streamFLag = true;
-        bool SLLMask = true;
-        bool CMPMask = true;
-        std::string inputStr = "";
 
-        if (!in || in.peek() == EOF) 
-        {
-            in.setstate(std::ios::failbit);
-            return in;
-        }
-        if (!(in >> sep{ '(' } && in >> sep{ ':' }))
-        {
-            streamFLag = false;
-        }
-        while (in && itter < 3 && streamFLag)
-        {
-            in >> label;
-            in >> std::ws;
-            option = static_cast<int>(label.exp[3]) - 48;
-            switch (option)
-            {
-            case 1:
-                std::getline(in, inputStr, ':');
-                if (std::regex_match(inputStr, REGEX_SLL_LIT))
-                {
-                    temp.key1 = std::stoll(inputStr);
-                }
-                else
-                {
-                    SLLMask = false;
-                }
-                break;
-            case 2:
-                std::getline(in, inputStr, ':');
-                if (std::regex_match(inputStr, REGEX_CMP_LSP))
-                {
-                    temp.key2 = parse_complex(inputStr);
-                }
-                else
-                {
-                    CMPMask = false;
-                }
-                break;
-            case 3:
-                in >> sep{ '\"' };
-                std::getline(in, inputStr, '\"');
-                in >> sep{ ':' };
-                if (in)
-                {
-                    temp.key3 = inputStr;
-                }
-                else
-                {
-                    streamFLag = false;
-                }
-                break;
-            default:
-                streamFLag = false;
-                break;
-            }
-            inputStr = "";
-            itter++;
-        }
+    char c;
+    using sep = DelimiterIO;
+    LabelIO label{ "" };
+    int iter = 0;
+    int option = 0;
+    bool streamFlag = true;
+    bool sllMask = true;
+    bool cmpMask = true;
+    std::string inputStr = "";
 
-        if (in && streamFLag && SLLMask && CMPMask && itter == 3 && (in >> sep{ ')' }))
-        {
-            data = temp;   
-            return in;
-        }
-        
+    if (!in || in.peek() == EOF) {
         in.setstate(std::ios::failbit);
-        in.clear();
-        in >> c;
-        while (in && c != ')')
-        {
-            if (in.peek() == EOF)
-            {
-                return in;
-            }
-            in >> c;
-        }
-        return operator>>(in, data);
+        return in;
     }
+
+    if (!(in >> sep{ '(' } && in >> sep{ ':' })) {
+        streamFlag = false;
+    }
+
+    while (in && iter < 3 && streamFlag) {
+        in >> label;
+        in >> std::ws;
+        option = static_cast<int>(label.exp[3]) - 48;
+
+        switch (option) {
+        case 1:
+            std::getline(in, inputStr, ':');
+            if (std::regex_match(inputStr, REGEX_SLL_LIT)) {
+                temp.key1 = std::stoll(inputStr);
+            }
+            else {
+                sllMask = false;
+            }
+            break;
+
+        case 2:
+            std::getline(in, inputStr, ':');
+            if (std::regex_match(inputStr, REGEX_CMP_LSP)) {
+                temp.key2 = parse_complex(inputStr);
+            }
+            else {
+                cmpMask = false;
+            }
+            break;
+
+        case 3:
+            in >> sep{ '\"' };
+            std::getline(in, inputStr, '\"');
+            in >> sep{ ':' };
+            if (in) {
+                temp.key3 = inputStr;
+            }
+            else {
+                streamFlag = false;
+            }
+            break;
+
+        default:
+            streamFlag = false;
+            break;
+        }
+
+        inputStr = "";
+        iter++;
+    }
+
+    if (in && streamFlag && sllMask && cmpMask && iter == 3 && (in >> sep{ ')' })) {
+        data = temp;
+        return in;
+    }
+
+    in.setstate(std::ios::failbit);
+    in.clear();
+    in >> c;
+    while (in && c != ')') {
+        if (in.peek() == EOF) {
+            return in;
+        }
+        in >> c;
+    }
+
+    return operator>>(in, data);
 }
 
 std::ostream& operator<<(std::ostream& out, const DataStruct& data)
@@ -181,13 +173,13 @@ std::ostream& operator<<(std::ostream& out, const DataStruct& data)
 
 bool compare(const DataStruct& a, const DataStruct& b)
 {
-    if (a.key1 != b.key1)
-    {
+    if (a.key1 != b.key1) {
         return a.key1 < b.key1;
     }
-    if (std::abs(a.key2) != std::abs(b.key2))
-    {
+
+    if (std::abs(a.key2) != std::abs(b.key2)) {
         return std::abs(a.key2) < std::abs(b.key2);
     }
+
     return a.key3.size() < b.key3.size();
 }

--- a/reshetnyak.igor/T2/DataStruct.cpp
+++ b/reshetnyak.igor/T2/DataStruct.cpp
@@ -71,9 +71,6 @@ std::istream& operator>>(std::istream& in, DataStruct& data)
         return in;
     }
 
-    long long key1 = 0ll;
-    std::complex<double> key2;
-    std::string key3;
     DataStruct temp;
 
     char c;

--- a/reshetnyak.igor/T2/DataStruct.cpp
+++ b/reshetnyak.igor/T2/DataStruct.cpp
@@ -50,7 +50,8 @@ std::istream& operator>>(std::istream& in, LabelIO& data)
 
     std::string s = "";
     in >> s;
-    bool invalidInput = in.eof() || s.length() != LENGTH_OF_LABEL; // Заменил 4 на переменную типа const int LENGTH_OF_LABEL = 4, которую проинициализировал в файле DataStruct.h 
+    // Заменил 4 на переменную типа const int LENGTH_OF_LABEL = 4, которую проинициализировал в файле DataStruct.h
+    bool invalidInput = in.eof() || s.length() != LENGTH_OF_LABEL;
     if (!invalidInput) {
         invalidInput = s.substr(0, 3) != "key" || !std::isdigit(s[3]);
     }
@@ -180,6 +181,6 @@ bool compare(const DataStruct& a, const DataStruct& b)
     if (std::abs(a.key2) != std::abs(b.key2)) {
         return std::abs(a.key2) < std::abs(b.key2);
     }
-
-    return a.key3.length() < b.key3.length(); // Заменил size на length. в задании требуется сортировать "По возрастанию длины строки key3, если прочие поля равны"
+    // Заменил size на length. в задании требуется сортировать "По возрастанию длины строки key3, если прочие поля равны"
+    return a.key3.length() < b.key3.length();
 }

--- a/reshetnyak.igor/T2/DataStruct.cpp
+++ b/reshetnyak.igor/T2/DataStruct.cpp
@@ -50,7 +50,7 @@ std::istream& operator>>(std::istream& in, LabelIO& data)
 
     std::string s = "";
     in >> s;
-    bool invalidInput = in.eof() || s.length() != 4;
+    bool invalidInput = in.eof() || s.length() != LENGTH_OF_LABEL; // Заменил 4 на переменную типа const int LENGTH_OF_LABEL = 4, которую проинициализировал в файле DataStruct.h 
     if (!invalidInput) {
         invalidInput = s.substr(0, 3) != "key" || !std::isdigit(s[3]);
     }
@@ -71,6 +71,9 @@ std::istream& operator>>(std::istream& in, DataStruct& data)
         return in;
     }
 
+    long long key1 = 0ll;
+    std::complex<double> key2;
+    std::string key3;
     DataStruct temp;
 
     char c;
@@ -178,5 +181,5 @@ bool compare(const DataStruct& a, const DataStruct& b)
         return std::abs(a.key2) < std::abs(b.key2);
     }
 
-    return a.key3.size() < b.key3.size();
+    return a.key3.length() < b.key3.length(); // Заменил size на length. в задании требуется сортировать "По возрастанию длины строки key3, если прочие поля равны"
 }

--- a/reshetnyak.igor/T2/DataStruct.cpp
+++ b/reshetnyak.igor/T2/DataStruct.cpp
@@ -1,0 +1,161 @@
+#include "DataStruct.h"
+
+std::complex<double> parseComplexManual(const std::string& str) {
+    size_t start = str.find('(') + 1;
+    size_t end = str.find(')');
+    std::string content = str.substr(start, end - start);
+
+    std::istringstream iss(content);
+    double real, imag;
+    iss >> real >> imag;
+
+    return std::complex<double>(real, imag);
+}
+
+std::ostream& operator<<(std::ostream& out, const DataStruct& data)
+{
+    StreamGuard guard(out);
+    out << "(:key1 " << data.key1 << "ll";
+    out << ":key2 #c(" << std::fixed << std::setprecision(1)
+        << data.key2.real() << " " << data.key2.imag() << ")";
+    out << ":key3 \"" << data.key3 << "\":)";
+    return out;
+}
+
+DataStruct getValues(const std::string& input)
+{
+    DataStruct temp = {
+        INVALID_LL_INDICATOR,
+        INVALID_CMP_INDICATOR,
+        INVALID_STR_INDICATOR
+    };
+
+    std::string str = input;
+    if (str.front() != '(' || str.back() != ')') return temp;
+    str = str.substr(1, str.size() - 2);
+
+    auto find_between = [](const std::string& source, const std::string& startKey, const std::string& endKey = "") {
+        size_t start = source.find(startKey);
+        if (start == std::string::npos) return std::string();
+        start += startKey.length();
+
+        size_t end = endKey.empty() ? std::string::npos : source.find(endKey, start);
+        return source.substr(start, end - start);
+        };
+
+    std::string val1 = find_between(str, ":key1 ", ":key2");
+    std::string val2 = find_between(str, ":key2 ", ":key3");
+    std::string val3 = find_between(str, ":key3 \"");
+    size_t quote_end = val3.find('"');
+    val3 = quote_end != std::string::npos ? val3.substr(0, quote_end) : "";
+
+    // key1
+    if (std::regex_match(val1, REGEX_SLL_LIT))
+    {
+        std::string num = val1.substr(0, val1.find("ll"));
+        temp.key1 = std::stoll(num);
+    }
+    else
+    {
+        return temp;
+    }
+
+    // key2
+    std::smatch match;
+    if (std::regex_match(val2, match, REGEX_CMP_LSP))
+    {
+        temp.key2 = std::complex<double>(std::stod(match[1]), std::stod(match[2]));
+    }
+    else
+    {
+        return temp;
+    }
+
+    // key3
+    if (!val3.empty())
+    {
+        temp.key3 = val3;
+    }
+    else
+    {
+        return temp;
+    }
+
+    return temp;
+}
+
+std::istream& operator>>(std::istream& in, DataStruct& dest)
+{
+    std::istream::sentry sentry(in);
+
+    if (!sentry)
+    {
+        in.setstate(std::ios::failbit);
+        return in;
+    }
+
+    std::string line;
+    char ch;
+
+    while (in >> ch && ch != '(');
+    if (in.eof())
+    {
+        in.setstate(std::ios::eofbit);
+        return in;
+    }
+
+    line += ch;
+
+    int depth = 1;
+    while (in.get(ch)) {
+        line += ch;
+        if (ch == '(') ++depth;
+        else if (ch == ')') {
+            --depth;
+            if (depth == 0) break;
+        }
+    }
+
+    if (depth != 0) {
+        return in;
+    }
+
+    DataStruct parsed = getValues(line);
+
+    if (parsed.key1 == INVALID_LL_INDICATOR || parsed.key2 == INVALID_CMP_INDICATOR || parsed.key3 == INVALID_STR_INDICATOR)
+    {
+        return in;
+    }
+
+    dest = std::move(parsed);
+    return in;
+}
+
+bool compareDataStruct(const DataStruct& a, const DataStruct& b)
+{
+    if (a.key1 != b.key1)
+    {
+        return a.key1 < b.key1;
+    }
+
+    double absA = std::abs(a.key2);
+    double absB = std::abs(b.key2);
+    if (absA != absB)
+    {
+        return absA < absB;
+    }
+
+    return a.key3.length() < b.key3.length();
+}
+
+StreamGuard::StreamGuard(std::basic_ios<char>& s) : s_(s)
+{
+    precision_ = s.precision();
+    flags_ = s.flags();
+}
+
+StreamGuard::~StreamGuard()
+{
+    s_.precision(precision_);
+    s_.flags(flags_);
+}

--- a/reshetnyak.igor/T2/DataStruct.cpp
+++ b/reshetnyak.igor/T2/DataStruct.cpp
@@ -1,161 +1,193 @@
-#include "DataStruct.h"
+﻿#include "DataStruct.h"
 
-std::complex<double> parseComplexManual(const std::string& str) {
-    size_t start = str.find('(') + 1;
-    size_t end = str.find(')');
-    std::string content = str.substr(start, end - start);
+StreamGuard::StreamGuard(std::basic_ios<char>& s) :
+	s_(s),
+	width_(s.width()),
+	fill_(s.fill()),
+	precision_(s.precision()),
+	fmt_(s.flags())
+{}
 
-    std::istringstream iss(content);
+StreamGuard::~StreamGuard()
+{
+	s_.width(width_);
+	s_.fill(fill_);
+	s_.precision(precision_);
+	s_.flags(fmt_);
+}
+
+std::complex<double> parse_complex(const std::string& input)
+{
+    std::complex<double> num;
     double real, imag;
+    std::string inner = input.substr(3, input.length() - 4);
+    std::istringstream iss(inner);
     iss >> real >> imag;
-
     return std::complex<double>(real, imag);
+}
+
+std::istream& operator>>(std::istream& in, DelimiterIO&& data)
+{
+    std::istream::sentry sentry(in);
+    if (!sentry)
+    {
+        return in;
+    }
+    char c = '0';
+    in >> c;
+    if (in && c != data.exp)
+    {
+        in.setstate(std::ios::failbit);
+    }
+    return in;
+}
+
+std::istream& operator>>(std::istream& in, LabelIO& data)
+{
+    std::istream::sentry sentry(in);
+    if (!sentry)
+    {
+        return in;
+    }
+    std::string s = "";
+    in >> s;
+    bool invalidInput = in.eof() || s.length() != 4;
+    if (!invalidInput)
+    {
+        invalidInput = s.substr(0, 3) != "key" || !(std::isdigit(s.c_str()[3]));
+    }
+    if (invalidInput)
+    {
+        in.setstate(std::ios::failbit);
+        return in;
+    }
+    data.exp = s;
+    return in;
+}
+
+std::istream& operator>>(std::istream& in, DataStruct& data)
+{
+    std::istream::sentry sentry(in);
+    if (!sentry)
+    {
+        return in;
+    }
+
+    long long key1 = 0ll;
+    std::complex<double> key2;
+    std::string key3;
+    DataStruct temp;
+    {
+        char c;
+        using sep = DelimiterIO;
+        LabelIO label{ "" };
+        int itter = 0;
+        int option = 0;
+        bool streamFLag = true;
+        bool SLLMask = true;
+        bool CMPMask = true;
+        std::string inputStr = "";
+
+        if (!in || in.peek() == EOF) 
+        {
+            in.setstate(std::ios::failbit);
+            return in;
+        }
+        if (!(in >> sep{ '(' } && in >> sep{ ':' }))
+        {
+            streamFLag = false;
+        }
+        while (in && itter < 3 && streamFLag)
+        {
+            in >> label;
+            in >> std::ws;
+            option = static_cast<int>(label.exp[3]) - 48;
+            switch (option)
+            {
+            case 1:
+                std::getline(in, inputStr, ':');
+                if (std::regex_match(inputStr, REGEX_SLL_LIT))
+                {
+                    temp.key1 = std::stoll(inputStr);
+                }
+                else
+                {
+                    SLLMask = false;
+                }
+                break;
+            case 2:
+                std::getline(in, inputStr, ':');
+                if (std::regex_match(inputStr, REGEX_CMP_LSP))
+                {
+                    temp.key2 = parse_complex(inputStr);
+                }
+                else
+                {
+                    CMPMask = false;
+                }
+                break;
+            case 3:
+                in >> sep{ '\"' };
+                std::getline(in, inputStr, '\"');
+                in >> sep{ ':' };
+                if (in)
+                {
+                    temp.key3 = inputStr;
+                }
+                else
+                {
+                    streamFLag = false;
+                }
+                break;
+            default:
+                streamFLag = false;
+                break;
+            }
+            inputStr = "";
+            itter++;
+        }
+
+        if (in && streamFLag && SLLMask && CMPMask && itter == 3 && (in >> sep{ ')' }))
+        {
+            data = temp;   
+            return in;
+        }
+        
+        in.setstate(std::ios::failbit);
+        in.clear();
+        in >> c;
+        while (in && c != ')')
+        {
+            if (in.peek() == EOF)
+            {
+                return in;
+            }
+            in >> c;
+        }
+        return operator>>(in, data);
+    }
 }
 
 std::ostream& operator<<(std::ostream& out, const DataStruct& data)
 {
     StreamGuard guard(out);
-    out << "(:key1 " << data.key1 << "ll";
-    out << ":key2 #c(" << std::fixed << std::setprecision(1)
-        << data.key2.real() << " " << data.key2.imag() << ")";
-    out << ":key3 \"" << data.key3 << "\":)";
+    out << "(:"
+        << "key1 " << data.key1 << "ll:"
+        << "key2 #c(" << std::fixed << std::setprecision(1)
+        << data.key2.real() << " " << data.key2.imag() << "):"
+        << "key3 \"" << data.key3 << "\":)";
     return out;
 }
 
-DataStruct getValues(const std::string& input)
-{
-    DataStruct temp = {
-        INVALID_LL_INDICATOR,
-        INVALID_CMP_INDICATOR,
-        INVALID_STR_INDICATOR
-    };
-
-    std::string str = input;
-    if (str.front() != '(' || str.back() != ')') return temp;
-    str = str.substr(1, str.size() - 2);
-
-    auto find_between = [](const std::string& source, const std::string& startKey, const std::string& endKey = "") {
-        size_t start = source.find(startKey);
-        if (start == std::string::npos) return std::string();
-        start += startKey.length();
-
-        size_t end = endKey.empty() ? std::string::npos : source.find(endKey, start);
-        return source.substr(start, end - start);
-        };
-
-    std::string val1 = find_between(str, ":key1 ", ":key2");
-    std::string val2 = find_between(str, ":key2 ", ":key3");
-    std::string val3 = find_between(str, ":key3 \"");
-    size_t quote_end = val3.find('"');
-    val3 = quote_end != std::string::npos ? val3.substr(0, quote_end) : "";
-
-    // key1
-    if (std::regex_match(val1, REGEX_SLL_LIT))
-    {
-        std::string num = val1.substr(0, val1.find("ll"));
-        temp.key1 = std::stoll(num);
-    }
-    else
-    {
-        return temp;
-    }
-
-    // key2
-    std::smatch match;
-    if (std::regex_match(val2, match, REGEX_CMP_LSP))
-    {
-        temp.key2 = std::complex<double>(std::stod(match[1]), std::stod(match[2]));
-    }
-    else
-    {
-        return temp;
-    }
-
-    // key3
-    if (!val3.empty())
-    {
-        temp.key3 = val3;
-    }
-    else
-    {
-        return temp;
-    }
-
-    return temp;
-}
-
-std::istream& operator>>(std::istream& in, DataStruct& dest)
-{
-    std::istream::sentry sentry(in);
-
-    if (!sentry)
-    {
-        in.setstate(std::ios::failbit);
-        return in;
-    }
-
-    std::string line;
-    char ch;
-
-    while (in >> ch && ch != '(');
-    if (in.eof())
-    {
-        in.setstate(std::ios::eofbit);
-        return in;
-    }
-
-    line += ch;
-
-    int depth = 1;
-    while (in.get(ch)) {
-        line += ch;
-        if (ch == '(') ++depth;
-        else if (ch == ')') {
-            --depth;
-            if (depth == 0) break;
-        }
-    }
-
-    if (depth != 0) {
-        return in;
-    }
-
-    DataStruct parsed = getValues(line);
-
-    if (parsed.key1 == INVALID_LL_INDICATOR || parsed.key2 == INVALID_CMP_INDICATOR || parsed.key3 == INVALID_STR_INDICATOR)
-    {
-        return in;
-    }
-
-    dest = std::move(parsed);
-    return in;
-}
-
-bool compareDataStruct(const DataStruct& a, const DataStruct& b)
+bool compare(const DataStruct& a, const DataStruct& b)
 {
     if (a.key1 != b.key1)
     {
         return a.key1 < b.key1;
     }
-
-    double absA = std::abs(a.key2);
-    double absB = std::abs(b.key2);
-    if (absA != absB)
+    if (std::abs(a.key2) != std::abs(b.key2))
     {
-        return absA < absB;
+        return std::abs(a.key2) < std::abs(b.key2);
     }
-
-    return a.key3.length() < b.key3.length();
-}
-
-StreamGuard::StreamGuard(std::basic_ios<char>& s) : s_(s)
-{
-    precision_ = s.precision();
-    flags_ = s.flags();
-}
-
-StreamGuard::~StreamGuard()
-{
-    s_.precision(precision_);
-    s_.flags(flags_);
+    return a.key3.size() < b.key3.size();
 }

--- a/reshetnyak.igor/T2/DataStruct.cpp
+++ b/reshetnyak.igor/T2/DataStruct.cpp
@@ -50,7 +50,6 @@ std::istream& operator>>(std::istream& in, LabelIO& data)
 
     std::string s = "";
     in >> s;
-    // Заменил 4 на переменную типа const int LENGTH_OF_LABEL = 4, которую проинициализировал в файле DataStruct.h
     bool invalidInput = in.eof() || s.length() != LENGTH_OF_LABEL;
     if (!invalidInput) {
         invalidInput = s.substr(0, 3) != "key" || !std::isdigit(s[3]);
@@ -181,6 +180,6 @@ bool compare(const DataStruct& a, const DataStruct& b)
     if (std::abs(a.key2) != std::abs(b.key2)) {
         return std::abs(a.key2) < std::abs(b.key2);
     }
-    // Заменил size на length. в задании требуется сортировать "По возрастанию длины строки key3, если прочие поля равны"
+
     return a.key3.length() < b.key3.length();
 }

--- a/reshetnyak.igor/T2/DataStruct.h
+++ b/reshetnyak.igor/T2/DataStruct.h
@@ -1,0 +1,44 @@
+#ifndef DATA_STRUCT_H
+#define DATA_STRUCT_H
+
+#include <iostream>
+#include <string>
+#include <regex>
+#include <complex>
+#include <vector>
+#include <algorithm>
+#include <iterator>
+#include <sstream>
+#include <cmath>
+#include <iomanip>
+
+const std::regex REGEX_SLL_LIT(R"(^[-]?([1-9][0-9]*)(ll|LL)$)");
+const std::regex REGEX_CMP_LSP(R"(^#c\(([-]?\d+\.\d+)\s([-]?\d+\.\d+)\)$)");
+
+const long long INVALID_LL_INDICATOR = 0ll;
+const std::complex<double> INVALID_CMP_INDICATOR = std::complex<double>(0, 0);
+const std::string INVALID_STR_INDICATOR = "";
+
+struct DataStruct {
+    long long key1;
+    std::complex<double> key2;
+    std::string key3;
+};
+
+class StreamGuard {
+public:
+    StreamGuard(std::basic_ios<char>& s);
+    ~StreamGuard();
+
+private:
+    std::basic_ios<char>& s_;
+    std::streamsize precision_;
+    std::basic_ios<char>::fmtflags flags_;
+};
+
+std::ostream& operator<<(std::ostream& out, const DataStruct& data);
+std::istream& operator>>(std::istream& in, DataStruct& data);
+bool compareDataStruct(const DataStruct& a, const DataStruct& b);
+DataStruct getValues(const std::string& input);
+
+#endif // DATA_STRUCT_H

--- a/reshetnyak.igor/T2/DataStruct.h
+++ b/reshetnyak.igor/T2/DataStruct.h
@@ -14,11 +14,12 @@
 
 const std::regex REGEX_SLL_LIT(R"(^[-]?([0]|[1-9][0-9]*)(ll|LL)$)");
 const std::regex REGEX_CMP_LSP(R"(^#c\(([-]?\d+\.\d+)\s([-]?\d+\.\d+)\)$)");
+const int LENGTH_OF_LABEL = 4;
 
 struct DataStruct
 {
-    long long key1;
-    std::complex<double> key2;
+    long long key1 = 0;
+    std::complex<double> key2{ 0.0, 0.0 };
     std::string key3;
 };
 

--- a/reshetnyak.igor/T2/DataStruct.h
+++ b/reshetnyak.igor/T2/DataStruct.h
@@ -2,15 +2,15 @@
 #define DATA_STRUCT_H
 
 #include <iostream>
+#include <iomanip>
 #include <sstream>
 #include <string>
-#include <cassert>
-#include <iterator>
 #include <vector>
-#include <iomanip>
-#include <regex>
+#include <iterator>
 #include <complex>
+#include <regex>
 #include <cmath>
+#include <cassert>
 
 const std::regex REGEX_SLL_LIT(R"(^[-]?([0]|[1-9][0-9]*)(ll|LL)$)");
 const std::regex REGEX_CMP_LSP(R"(^#c\(([-]?\d+\.\d+)\s([-]?\d+\.\d+)\)$)");
@@ -35,20 +35,23 @@ struct LabelIO
 class StreamGuard
 {
 public:
-    StreamGuard(std::basic_ios<char>& s);
+    explicit StreamGuard(std::basic_ios<char>& s);
     ~StreamGuard();
+
 private:
-    std::basic_ios< char >& s_;
+    std::basic_ios<char>& s_;
     std::streamsize width_;
     char fill_;
     std::streamsize precision_;
-    std::basic_ios< char >::fmtflags fmt_;
+    std::basic_ios<char>::fmtflags fmt_;
 };
 
 std::istream& operator>>(std::istream& in, DelimiterIO&& data);
 std::istream& operator>>(std::istream& in, LabelIO& data);
 std::istream& operator>>(std::istream& in, DataStruct& input);
 std::ostream& operator<<(std::ostream& out, const DataStruct& output);
+
 std::complex<double> parse_complex(const std::string& input);
 bool compare(const DataStruct& a, const DataStruct& b);
-#endif
+
+#endif // DATA_STRUCT_H

--- a/reshetnyak.igor/T2/DataStruct.h
+++ b/reshetnyak.igor/T2/DataStruct.h
@@ -2,43 +2,53 @@
 #define DATA_STRUCT_H
 
 #include <iostream>
+#include <sstream>
 #include <string>
+#include <cassert>
+#include <iterator>
+#include <vector>
+#include <iomanip>
 #include <regex>
 #include <complex>
-#include <vector>
-#include <algorithm>
-#include <iterator>
-#include <sstream>
 #include <cmath>
-#include <iomanip>
 
-const std::regex REGEX_SLL_LIT(R"(^[-]?([1-9][0-9]*)(ll|LL)$)");
+const std::regex REGEX_SLL_LIT(R"(^[-]?([0]|[1-9][0-9]*)(ll|LL)$)");
 const std::regex REGEX_CMP_LSP(R"(^#c\(([-]?\d+\.\d+)\s([-]?\d+\.\d+)\)$)");
 
-const long long INVALID_LL_INDICATOR = 0ll;
-const std::complex<double> INVALID_CMP_INDICATOR = std::complex<double>(0, 0);
-const std::string INVALID_STR_INDICATOR = "";
-
-struct DataStruct {
+struct DataStruct
+{
     long long key1;
     std::complex<double> key2;
     std::string key3;
 };
 
-class StreamGuard {
+struct DelimiterIO
+{
+    char exp;
+};
+
+struct LabelIO
+{
+    std::string exp;
+};
+
+class StreamGuard
+{
 public:
     StreamGuard(std::basic_ios<char>& s);
     ~StreamGuard();
-
 private:
-    std::basic_ios<char>& s_;
+    std::basic_ios< char >& s_;
+    std::streamsize width_;
+    char fill_;
     std::streamsize precision_;
-    std::basic_ios<char>::fmtflags flags_;
+    std::basic_ios< char >::fmtflags fmt_;
 };
 
-std::ostream& operator<<(std::ostream& out, const DataStruct& data);
-std::istream& operator>>(std::istream& in, DataStruct& data);
-bool compareDataStruct(const DataStruct& a, const DataStruct& b);
-DataStruct getValues(const std::string& input);
-
-#endif // DATA_STRUCT_H
+std::istream& operator>>(std::istream& in, DelimiterIO&& data);
+std::istream& operator>>(std::istream& in, LabelIO& data);
+std::istream& operator>>(std::istream& in, DataStruct& input);
+std::ostream& operator<<(std::ostream& out, const DataStruct& output);
+std::complex<double> parse_complex(const std::string& input);
+bool compare(const DataStruct& a, const DataStruct& b);
+#endif

--- a/reshetnyak.igor/T2/main.cpp
+++ b/reshetnyak.igor/T2/main.cpp
@@ -1,18 +1,7 @@
 #include "DataStruct.h"
 
-void cleanVector(std::vector<DataStruct>& vector) {
-    vector.erase(
-        std::remove_if(vector.begin(), vector.end(),
-            [](const DataStruct& ds) {
-                return ds.key1 == INVALID_LL_INDICATOR &&
-                    ds.key2 == INVALID_CMP_INDICATOR &&
-                    ds.key3 == INVALID_STR_INDICATOR;
-            }),
-        vector.end()
-    );
-}
-
-int main() {
+int main()
+{
     std::vector<DataStruct> dataVector;
 
     std::copy(
@@ -21,20 +10,14 @@ int main() {
         std::back_inserter(dataVector)
     );
 
-    cleanVector(dataVector);
-
-    if (dataVector.empty()) {
-        std::cerr << "Empty dataVector\n";
-        return 0;
+    if (dataVector.empty())
+    {
+        std::cout << "Empty dataVector";
     }
 
-    std::sort(dataVector.begin(), dataVector.end(), compareDataStruct);
+    std::sort(dataVector.begin(), dataVector.end(), compare);
 
-    std::copy(
-        dataVector.begin(),
-        dataVector.end(),
-        std::ostream_iterator<DataStruct>(std::cout, "\n")
-    );
+    std::copy(dataVector.begin(), dataVector.end(), std::ostream_iterator<DataStruct>(std::cout, "\n"));
 
     return EXIT_SUCCESS;
 }

--- a/reshetnyak.igor/T2/main.cpp
+++ b/reshetnyak.igor/T2/main.cpp
@@ -1,0 +1,40 @@
+#include "DataStruct.h"
+
+void cleanVector(std::vector<DataStruct>& vector) {
+    vector.erase(
+        std::remove_if(vector.begin(), vector.end(),
+            [](const DataStruct& ds) {
+                return ds.key1 == INVALID_LL_INDICATOR &&
+                    ds.key2 == INVALID_CMP_INDICATOR &&
+                    ds.key3 == INVALID_STR_INDICATOR;
+            }),
+        vector.end()
+    );
+}
+
+int main() {
+    std::vector<DataStruct> dataVector;
+
+    std::copy(
+        std::istream_iterator<DataStruct>(std::cin),
+        std::istream_iterator<DataStruct>(),
+        std::back_inserter(dataVector)
+    );
+
+    cleanVector(dataVector);
+
+    if (dataVector.empty()) {
+        std::cerr << "Empty dataVector\n";
+        return 0;
+    }
+
+    std::sort(dataVector.begin(), dataVector.end(), compareDataStruct);
+
+    std::copy(
+        dataVector.begin(),
+        dataVector.end(),
+        std::ostream_iterator<DataStruct>(std::cout, "\n")
+    );
+
+    return EXIT_SUCCESS;
+}

--- a/reshetnyak.igor/T2/main.cpp
+++ b/reshetnyak.igor/T2/main.cpp
@@ -9,23 +9,37 @@ int main()
 {
     std::vector<DataStruct> dataVector;
 
-    std::copy(
-        std::istream_iterator<DataStruct>(std::cin),
-        std::istream_iterator<DataStruct>(),
-        std::back_inserter(dataVector)
-    );
+    try {
+        std::ios_base::iostate original_state = std::cin.rdstate(); // Сохраняем текущее состояние потока
 
-    if (dataVector.empty()) {
-        std::cout << "Empty dataVector";
+        std::copy(
+            std::istream_iterator<DataStruct>(std::cin),
+            std::istream_iterator<DataStruct>(),
+            std::back_inserter(dataVector)
+        );
+
+        if (std::cin.fail() && !std::cin.eof()) { // Проверка на ошибки cin.fail, кроме eof
+            std::cin.clear(original_state | std::ios_base::eofbit);
+            throw std::runtime_error("Error reading from input");
+        }
+
+        if (dataVector.empty()) {
+            std::cout << "Empty dataVector\n";
+        }
+        else {
+            std::sort(dataVector.begin(), dataVector.end(), compare);
+
+            std::copy(
+                dataVector.begin(),
+                dataVector.end(),
+                std::ostream_iterator<DataStruct>(std::cout, "\n")
+            );
+        }
     }
-
-    std::sort(dataVector.begin(), dataVector.end(), compare);
-
-    std::copy(
-        dataVector.begin(),
-        dataVector.end(),
-        std::ostream_iterator<DataStruct>(std::cout, "\n")
-    );
+    catch (const std::exception& e) {
+        std::cerr << e.what() << '\n';
+        return EXIT_FAILURE;
+    }
 
     return EXIT_SUCCESS;
 }

--- a/reshetnyak.igor/T2/main.cpp
+++ b/reshetnyak.igor/T2/main.cpp
@@ -1,4 +1,9 @@
 #include "DataStruct.h"
+#include <algorithm>
+#include <iterator>
+#include <vector>
+#include <iostream>
+#include <cstdlib>
 
 int main()
 {
@@ -10,14 +15,17 @@ int main()
         std::back_inserter(dataVector)
     );
 
-    if (dataVector.empty())
-    {
+    if (dataVector.empty()) {
         std::cout << "Empty dataVector";
     }
 
     std::sort(dataVector.begin(), dataVector.end(), compare);
 
-    std::copy(dataVector.begin(), dataVector.end(), std::ostream_iterator<DataStruct>(std::cout, "\n"));
+    std::copy(
+        dataVector.begin(),
+        dataVector.end(),
+        std::ostream_iterator<DataStruct>(std::cout, "\n")
+    );
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Заменил регулярное выражение для SLL LIT
^[-]?([0]|[1-9][0-9]*)(ll|LL)$ - теперь обрабатываются значения 0ll и 0LL